### PR TITLE
fix Typo and extend support for floating label

### DIFF
--- a/src/jbvalidator.js
+++ b/src/jbvalidator.js
@@ -8,7 +8,7 @@
             errorMessage: true,
             successClass: false,
             html5BrowserDefault: false,
-            validFeedBackClass: 'valid-feedbak',
+            validFeedBackClass: 'valid-feedback',
             invalidFeedBackClass: 'invalid-feedback',
             validClass: 'is-valid',
             invalidClass: 'is-invalid'

--- a/src/jbvalidator.js
+++ b/src/jbvalidator.js
@@ -195,6 +195,12 @@
             if (options.successClass) {
                 $(el).addClass(options.validClass);
             }
+
+            let label = $(el).parent().find("label");
+            if(typeof label!=="undefined"){
+              $(label[0]).removeClass(options.invalidFeedBackClass);
+              $(label[0]).addClass(options.validFeedBackClass);
+            }
         }
 
         let validator = {

--- a/src/jbvalidator.js
+++ b/src/jbvalidator.js
@@ -186,6 +186,11 @@
                     }
                 }
             }
+            let label = $(el).parent().find("label");
+            if(typeof label!=="undefined"){
+              $(label[0]).removeClass(options.validFeedBackClass);
+              $(label[0]).addClass(options.invalidFeedBackClass);
+            }
         }
 
         let hideErrorMessage = function (el) {


### PR DESCRIPTION
Hi!

(First at all this is my first contribution to an external repo).

I found a wrong typo on the classname for `validFeedBackClass`. 
Also found a kind-of-bug when using float labels and the server responses with `is-invalid` css class, the label 'disappears' from the screen in any form-control, so I made a little fix to give support for it.

Form returned from server
![Captura de Pantalla 2021-03-29 a la(s) 16 56 24](https://user-images.githubusercontent.com/62568995/112894031-c265e180-90b1-11eb-8eac-b987d203e86e.png)

Right option selected
![Captura de Pantalla 2021-03-29 a la(s) 16 56 31](https://user-images.githubusercontent.com/62568995/112894077-cd207680-90b1-11eb-8c8f-ff116308a042.png)

With the fix 
![Captura de Pantalla 2021-03-29 a la(s) 16 56 42](https://user-images.githubusercontent.com/62568995/112894114-d6a9de80-90b1-11eb-8a59-be398ad67b9e.png)



Thanks!